### PR TITLE
Add Russian localization support

### DIFF
--- a/FactCheckerApp/FactCheckerApp/Views/SettingsView.swift
+++ b/FactCheckerApp/FactCheckerApp/Views/SettingsView.swift
@@ -464,6 +464,7 @@ enum SupportedLanguage: String, CaseIterable {
     case portuguese = "pt-BR"
     case chinese = "zh-CN"
     case japanese = "ja-JP"
+    case russian = "ru-RU"
     
     var displayName: String {
         switch self {
@@ -475,6 +476,7 @@ enum SupportedLanguage: String, CaseIterable {
         case .portuguese: return "Portuguese"
         case .chinese: return "Chinese"
         case .japanese: return "Japanese"
+        case .russian: return "Russian"
         }
     }
 }

--- a/FactCheckerApp/FactCheckerApp/en.lproj/Localizable.strings
+++ b/FactCheckerApp/FactCheckerApp/en.lproj/Localizable.strings
@@ -1,0 +1,204 @@
+/* General */
+"app_name" = "FactCheck Pro";
+"ok" = "OK";
+"cancel" = "Cancel";
+"done" = "Done";
+"save" = "Save";
+"delete" = "Delete";
+"edit" = "Edit";
+"back" = "Back";
+"next" = "Next";
+"continue" = "Continue";
+"retry" = "Retry";
+
+/* Main Interface */
+"start_listening" = "Start Listening";
+"stop_listening" = "Stop Listening";
+"ready_to_factcheck" = "Ready to fact-check";
+"listening" = "Listening...";
+"processing" = "Processing...";
+"fact_checking" = "Fact-checking...";
+
+/* Fact Check Results */
+"statement_true" = "True";
+"statement_false" = "False";
+"statement_mixed" = "Mixed";
+"statement_unknown" = "Unknown";
+"confidence" = "Confidence";
+"sources" = "Sources";
+"processing_time" = "Processing Time";
+"claim_type" = "Claim Type";
+
+/* Navigation */
+"tab_factcheck" = "Fact Check";
+"tab_history" = "History";
+"tab_statistics" = "Statistics";
+"tab_speakers" = "Speakers";
+"tab_settings" = "Settings";
+
+/* History */
+"history_title" = "History";
+"search_history" = "Search history...";
+"filter_results" = "Filter";
+"no_results" = "No results found";
+"clear_history" = "Clear History";
+"export_history" = "Export History";
+
+/* Statistics */
+"statistics_title" = "Statistics";
+"total_checks" = "Total Checks";
+"accuracy_rate" = "Accuracy Rate";
+"average_confidence" = "Average Confidence";
+"verification_rate" = "Verification Rate";
+"timeframe_today" = "Today";
+"timeframe_week" = "This Week";
+"timeframe_month" = "This Month";
+"timeframe_year" = "This Year";
+"timeframe_all" = "All Time";
+
+/* Speakers */
+"speakers_title" = "Speakers";
+"add_speaker" = "Add Speaker";
+"speaker_name" = "Speaker Name";
+"voice_sample" = "Voice Sample";
+"record_sample" = "Record Sample";
+"unknown_speaker" = "Unknown Speaker";
+
+/* Settings */
+"settings_title" = "Settings";
+"general" = "General";
+"theme" = "Theme";
+"theme_system" = "System";
+"theme_light" = "Light";
+"theme_dark" = "Dark";
+"haptic_feedback" = "Haptic Feedback";
+"notifications" = "Notifications";
+
+"factchecking" = "Fact Checking";
+"realtime_factchecking" = "Real-time Fact Checking";
+"confidence_threshold" = "Confidence Threshold";
+"source_verification" = "Source Verification";
+"max_sources" = "Max Sources per Check";
+
+"audio_speech" = "Audio & Speech";
+"speaker_identification" = "Speaker Identification";
+"audio_sensitivity" = "Audio Sensitivity";
+"language" = "Language";
+"continuous_listening" = "Continuous Listening";
+
+"privacy_security" = "Privacy & Security";
+"anonymous_analytics" = "Anonymous Analytics";
+"store_audio_locally" = "Store Audio Locally";
+"privacy_policy" = "Privacy Policy";
+"data_retention" = "Data Retention";
+
+"data_management" = "Data Management";
+"storage_used" = "Storage Used";
+"export_data" = "Export Data";
+"clear_cache" = "Clear Cache";
+"reset_all_data" = "Reset All Data";
+
+"about" = "About";
+"version" = "Version";
+"rate_app" = "Rate App";
+"contact_support" = "Contact Support";
+
+/* Onboarding */
+"onboarding_welcome_title" = "Real-time Fact Checking";
+"onboarding_welcome_description" = "Automatically verify statements as they're spoken using advanced AI and multiple reliable sources.";
+
+"onboarding_speakers_title" = "Speaker Identification";
+"onboarding_speakers_description" = "Identify different speakers and track their fact-checking history over time.";
+
+"onboarding_analytics_title" = "Detailed Analytics";
+"onboarding_analytics_description" = "View comprehensive statistics about accuracy rates, claim types, and verification trends.";
+
+"onboarding_privacy_title" = "Privacy First";
+"onboarding_privacy_description" = "Your data stays on your device. Audio processing is done locally whenever possible.";
+
+"get_started" = "Get Started";
+"permissions_required" = "Permissions Required";
+"permissions_description" = "FactCheck Pro needs these permissions to work properly";
+
+"microphone_access" = "Microphone Access";
+"microphone_description" = "Required to listen to and transcribe speech";
+"speech_recognition" = "Speech Recognition";
+"speech_recognition_description" = "Converts speech to text for fact-checking";
+"notifications_permission" = "Notifications";
+"notifications_description" = "Get alerts about fact-check results";
+
+"allow" = "Allow";
+"settings" = "Settings";
+
+/* Errors */
+"error_title" = "Error";
+"error_microphone_permission" = "Microphone permission is required for fact-checking";
+"error_speech_recognition" = "Speech recognition is not available";
+"error_network" = "Network connection required for fact-checking";
+"error_processing" = "Error processing statement";
+"error_no_statement" = "No statement detected";
+"error_statement_too_short" = "Statement too short to fact-check";
+"error_statement_too_long" = "Statement too long to process";
+
+/* Accessibility */
+"accessibility_start_listening" = "Start listening for speech to fact-check";
+"accessibility_stop_listening" = "Stop listening for speech";
+"accessibility_fact_result" = "Fact check result";
+"accessibility_confidence_level" = "Confidence level";
+"accessibility_source_count" = "Number of sources";
+"accessibility_speaker_identified" = "Speaker identified";
+
+/* Data Retention */
+"retention_1week" = "1 Week";
+"retention_1month" = "1 Month";
+"retention_3months" = "3 Months";
+"retention_6months" = "6 Months";
+"retention_1year" = "1 Year";
+"retention_forever" = "Forever";
+
+/* Languages */
+"language_english" = "English";
+"language_spanish" = "Spanish";
+"language_french" = "French";
+"language_german" = "German";
+"language_italian" = "Italian";
+"language_portuguese" = "Portuguese";
+"language_chinese" = "Chinese";
+"language_japanese" = "Japanese";
+
+/* Claim Types */
+"claim_factual" = "Factual";
+"claim_statistical" = "Statistical";
+"claim_quote" = "Quote";
+"claim_prediction" = "Prediction";
+"claim_opinion" = "Opinion";
+
+/* Export */
+"export_format" = "Export Format";
+"export_csv" = "CSV";
+"export_json" = "JSON";
+"export_pdf" = "PDF";
+"export_success" = "Data exported successfully";
+"export_error" = "Error exporting data";
+
+/* Alerts */
+"alert_clear_history_title" = "Clear History";
+"alert_clear_history_message" = "This will permanently delete all fact-check history. This action cannot be undone.";
+"alert_reset_data_title" = "Reset All Data";
+"alert_reset_data_message" = "This will permanently delete all fact-check history, speakers, and settings. This action cannot be undone.";
+"alert_delete_speaker_title" = "Delete Speaker";
+"alert_delete_speaker_message" = "Are you sure you want to delete this speaker profile?";
+
+/* Voice Samples */
+"record_voice_sample" = "Record Voice Sample";
+"recording_voice_sample" = "Recording...";
+"voice_sample_recorded" = "Voice sample recorded";
+"voice_sample_too_short" = "Voice sample too short. Please record for at least 3 seconds.";
+"voice_sample_error" = "Error recording voice sample";
+
+/* Network Status */
+"network_connected" = "Connected";
+"network_disconnected" = "Disconnected";
+"network_limited" = "Limited Connection";
+"offline_mode" = "Offline Mode";
+"online_mode" = "Online Mode";

--- a/FactCheckerApp/FactCheckerApp/ru.lproj/Localizable.strings
+++ b/FactCheckerApp/FactCheckerApp/ru.lproj/Localizable.strings
@@ -1,0 +1,204 @@
+/* General */
+"app_name" = "Factcheck Pro";
+"ok" = "ХОРОШО";
+"cancel" = "Отмена";
+"done" = "Сделанный";
+"save" = "Сохранять";
+"delete" = "Удалить";
+"edit" = "Редактировать";
+"back" = "Назад";
+"next" = "Следующий";
+"continue" = "Продолжать";
+"retry" = "Повторно";
+
+/* Main Interface */
+"start_listening" = "Начните слушать";
+"stop_listening" = "Перестань слушать";
+"ready_to_factcheck" = "Готов к проверке фактов";
+"listening" = "Слушание ...";
+"processing" = "Обработка...";
+"fact_checking" = "Проверка фактов ...";
+
+/* Fact Check Results */
+"statement_true" = "Истинный";
+"statement_false" = "ЛОЖЬ";
+"statement_mixed" = "Смешанный";
+"statement_unknown" = "Неизвестный";
+"confidence" = "Уверенность";
+"sources" = "Источники";
+"processing_time" = "Время обработки";
+"claim_type" = "Тип претензии";
+
+/* Navigation */
+"tab_factcheck" = "Проверка фактов";
+"tab_history" = "История";
+"tab_statistics" = "Статистика";
+"tab_speakers" = "Докладчики";
+"tab_settings" = "Настройки";
+
+/* History */
+"history_title" = "История";
+"search_history" = "История поиска ...";
+"filter_results" = "Фильтр";
+"no_results" = "Результаты не обнаружены";
+"clear_history" = "Ясная история";
+"export_history" = "История экспорта";
+
+/* Statistics */
+"statistics_title" = "Статистика";
+"total_checks" = "Общие чеки";
+"accuracy_rate" = "Скорость точности";
+"average_confidence" = "Средняя уверенность";
+"verification_rate" = "Скорость проверки";
+"timeframe_today" = "Сегодня";
+"timeframe_week" = "На этой неделе";
+"timeframe_month" = "В этом месяце";
+"timeframe_year" = "В этом году";
+"timeframe_all" = "Все время";
+
+/* Speakers */
+"speakers_title" = "Докладчики";
+"add_speaker" = "Добавить динамик";
+"speaker_name" = "Название спикера";
+"voice_sample" = "Образец голоса";
+"record_sample" = "Запись образец";
+"unknown_speaker" = "Неизвестный оратор";
+
+/* Settings */
+"settings_title" = "Настройки";
+"general" = "Общий";
+"theme" = "Тема";
+"theme_system" = "Система";
+"theme_light" = "Свет";
+"theme_dark" = "Темный";
+"haptic_feedback" = "Хаптическая обратная связь";
+"notifications" = "Уведомления";
+
+"factchecking" = "Проверка фактов";
+"realtime_factchecking" = "Проверка фактов в реальном времени";
+"confidence_threshold" = "Порог уверенности";
+"source_verification" = "Проверка источника";
+"max_sources" = "Максимальные источники за чек";
+
+"audio_speech" = "Аудио и речь";
+"speaker_identification" = "Идентификация спикера";
+"audio_sensitivity" = "Аудио чувствительность";
+"language" = "Язык";
+"continuous_listening" = "Непрерывное слушание";
+
+"privacy_security" = "Конфиденциальность и безопасность";
+"anonymous_analytics" = "Анонимная аналитика";
+"store_audio_locally" = "Хранить аудио на местном уровне";
+"privacy_policy" = "политика конфиденциальности";
+"data_retention" = "Удержание данных";
+
+"data_management" = "Управление данными";
+"storage_used" = "Хранилище используется";
+"export_data" = "Экспортные данные";
+"clear_cache" = "Чистый кеш";
+"reset_all_data" = "Сбросить все данные";
+
+"about" = "О";
+"version" = "Версия";
+"rate_app" = "Оценка приложения";
+"contact_support" = "Контактная поддержка";
+
+/* Onboarding */
+"onboarding_welcome_title" = "Проверка фактов в реальном времени";
+"onboarding_welcome_description" = "Автоматически проверяйте операторы, как они говорят, используя расширенный ИИ и несколько надежных источников.";
+
+"onboarding_speakers_title" = "Идентификация спикера";
+"onboarding_speakers_description" = "Определите разные ораторы и отслеживайте их историю проверки фактов с течением времени.";
+
+"onboarding_analytics_title" = "Подробная аналитика";
+"onboarding_analytics_description" = "Просмотреть комплексную статистику о показателях точности, типах претензий и тенденциях проверки.";
+
+"onboarding_privacy_title" = "Конфиденциальность сначала";
+"onboarding_privacy_description" = "Ваши данные остаются на вашем устройстве. ";
+
+"get_started" = "Начните";
+"permissions_required" = "Требуются разрешения";
+"permissions_description" = "FactCheck Pro нуждается в этих разрешениях для правильной работы";
+
+"microphone_access" = "Доступ к микрофону";
+"microphone_description" = "Требуется слушать и транскрибировать речь";
+"speech_recognition" = "Распознавание речи";
+"speech_recognition_description" = "Преобразует речь в текст для проверки фактов";
+"notifications_permission" = "Уведомления";
+"notifications_description" = "Получите оповещения о результатах проверки фактов";
+
+"allow" = "Позволять";
+"settings" = "Настройки";
+
+/* Errors */
+"error_title" = "Ошибка";
+"error_microphone_permission" = "Для проверки фактов требуется разрешение на микрофон";
+"error_speech_recognition" = "Распознавание речи недоступно";
+"error_network" = "Сетевое соединение, необходимое для проверки фактов";
+"error_processing" = "Оператор обработки ошибок";
+"error_no_statement" = "Заявление не обнаружено";
+"error_statement_too_short" = "Заявление слишком короткое, чтобы проверить факты";
+"error_statement_too_long" = "Заявление слишком долго, чтобы обработать";
+
+/* Accessibility */
+"accessibility_start_listening" = "Начните слушать речь к проверке фактов";
+"accessibility_stop_listening" = "Прекратите слушать речь";
+"accessibility_fact_result" = "Результат проверки фактов";
+"accessibility_confidence_level" = "Уровень уверенности";
+"accessibility_source_count" = "Количество источников";
+"accessibility_speaker_identified" = "Спикер идентифицирован";
+
+/* Data Retention */
+"retention_1week" = "1 неделя";
+"retention_1month" = "1 месяц";
+"retention_3months" = "3 месяца";
+"retention_6months" = "6 месяцев";
+"retention_1year" = "1 год";
+"retention_forever" = "Навсегда";
+
+/* Languages */
+"language_english" = "Английский";
+"language_spanish" = "испанский";
+"language_french" = "Французский";
+"language_german" = "немецкий";
+"language_italian" = "Итальянский";
+"language_portuguese" = "португальский";
+"language_chinese" = "китайский";
+"language_japanese" = "Японский";
+
+/* Claim Types */
+"claim_factual" = "Фактический";
+"claim_statistical" = "Статистический";
+"claim_quote" = "Цитировать";
+"claim_prediction" = "Прогноз";
+"claim_opinion" = "Мнение";
+
+/* Export */
+"export_format" = "Формат экспорта";
+"export_csv" = "CSV";
+"export_json" = "Json";
+"export_pdf" = "PDF";
+"export_success" = "Данные успешно экспортировались";
+"export_error" = "Ошибка экспорта данных";
+
+/* Alerts */
+"alert_clear_history_title" = "Ясная история";
+"alert_clear_history_message" = "Это навсегда удалит всю историю проверки фактов. ";
+"alert_reset_data_title" = "Сбросить все данные";
+"alert_reset_data_message" = "Это навсегда удалит всю историю проверки фактов, докладчики и настройки. ";
+"alert_delete_speaker_title" = "Удалить динамик";
+"alert_delete_speaker_message" = "Вы уверены, что хотите удалить этот профиль динамика?";
+
+/* Voice Samples */
+"record_voice_sample" = "Запись голосового образца";
+"recording_voice_sample" = "Запись ...";
+"voice_sample_recorded" = "Образец голоса записан";
+"voice_sample_too_short" = "Образец голоса слишком короткий. ";
+"voice_sample_error" = "Образец голосовой записи ошибок";
+
+/* Network Status */
+"network_connected" = "Подключенный";
+"network_disconnected" = "Отключен";
+"network_limited" = "Ограниченное соединение";
+"offline_mode" = "Автономный режим";
+"online_mode" = "Онлайн -режим";


### PR DESCRIPTION
## Summary
- add Russian localization strings
- provide English strings under `en.lproj`
- extend `SupportedLanguage` enum with Russian case

## Testing
- `xcodebuild test -scheme FactCheckPro -destination 'platform=iOS Simulator,name=iPhone 14'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68837872e5f083239f18c1ea0b6720bf