### PR TITLE
Fix module imports in tests

### DIFF
--- a/FactCheckerApp/FactCheckerAppTests/FactCheckServiceTests.swift
+++ b/FactCheckerApp/FactCheckerAppTests/FactCheckServiceTests.swift
@@ -8,7 +8,7 @@
 
 import XCTest
 import Combine
-@testable import FactCheckPro
+@testable import FactCheckerApp
 
 class FactCheckServiceTests: XCTestCase {
     var factCheckService: FactCheckService!

--- a/FactCheckerApp/FactCheckerAppTests/FactCheckerAppTests.swift
+++ b/FactCheckerApp/FactCheckerAppTests/FactCheckerAppTests.swift
@@ -1,8 +1,8 @@
 import XCTest
-@testable import FactCheckPro
+@testable import FactCheckerApp
 import Combine
 
-class FactCheckProTests: XCTestCase {
+class FactCheckerAppTests: XCTestCase {
     var coordinator: FactCheckCoordinator!
     var mockAudioService: MockAudioService!
     var mockFactCheckService: MockFactCheckService!

--- a/FactCheckerApp/FactCheckerAppTests/PerformanceTests.swift
+++ b/FactCheckerApp/FactCheckerAppTests/PerformanceTests.swift
@@ -7,7 +7,7 @@
 
 
 import XCTest
-@testable import FactCheckPro
+@testable import FactCheckerApp
 
 class PerformanceTests: XCTestCase {
     var coordinator: FactCheckCoordinator!

--- a/FactCheckerApp/FactCheckerAppTests/SpeakerServiceTests.swift
+++ b/FactCheckerApp/FactCheckerAppTests/SpeakerServiceTests.swift
@@ -7,7 +7,7 @@
 
 
 import XCTest
-@testable import FactCheckPro
+@testable import FactCheckerApp
 
 class SpeakerServiceTests: XCTestCase {
     var speakerService: SpeakerService!

--- a/FactCheckerApp/FactCheckerAppUITests/FactCheckProUITests.swift
+++ b/FactCheckerApp/FactCheckerAppUITests/FactCheckProUITests.swift
@@ -1,5 +1,5 @@
 //
-//  FactCheckProUITests.swift
+//  FactCheckerAppUITests.swift
 //  FactCheckerApp
 //
 //  Created by Nicholas Myer on 7/25/25.
@@ -8,7 +8,7 @@
 
 import XCTest
 
-class FactCheckProUITests: XCTestCase {
+class FactCheckerAppUITests: XCTestCase {
     var app: XCUIApplication!
     
     override func setUpWithError() throws {

--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
 # FactCheckerApp
+
+This repository contains an iOS application built with SwiftUI. The app provides real-time fact checking using speech recognition, speaker identification and other services.
+
+The project is developed in Xcode and includes unit tests and UI tests. To build and run the project open `FactCheckerApp.xcodeproj` in Xcode 15 or later.
+
+```
+open FactCheckerApp.xcodeproj
+```
+
+Run tests from within Xcode using the test navigator.


### PR DESCRIPTION
## Summary
- update README with brief setup instructions
- fix unit test imports to use the proper module name
- update UI test class name and header

## Testing
- `xcodebuild -list` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6883733476348323b499f578c5a16efb