### PR TITLE
Fix Info.plist path for FactCheckerApp target

### DIFF
--- a/FactCheckerApp/FactCheckerApp.xcodeproj/project.pbxproj
+++ b/FactCheckerApp/FactCheckerApp.xcodeproj/project.pbxproj
@@ -315,7 +315,7 @@
 				DEVELOPMENT_TEAM = HV8Z5KUF4P;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
-				INFOPLIST_FILE = FactCheckerApp/Info.plist;
+                               INFOPLIST_FILE = FactCheckerApp/App/Info.plist;
 				INFOPLIST_KEY_NSMicrophoneUsageDescription = "FactCheck Pro needs microphone access to listen to and transcribe speech for fact-checking.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -346,7 +346,7 @@
 				DEVELOPMENT_TEAM = HV8Z5KUF4P;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
-				INFOPLIST_FILE = FactCheckerApp/Info.plist;
+                               INFOPLIST_FILE = FactCheckerApp/App/Info.plist;
 				INFOPLIST_KEY_NSMicrophoneUsageDescription = "FactCheck Pro needs microphone access to listen to and transcribe speech for fact-checking.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;


### PR DESCRIPTION
## Summary
- point the FactCheckerApp target to the correct Info.plist

## Testing
- `xcodebuild -project FactCheckerApp/FactCheckerApp.xcodeproj -scheme FactCheckerApp -sdk iphonesimulator -configuration Debug -derivedDataPath build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6883e098d05c8323adf84d7ee9b7285a