### PR TITLE
Add workflow test cases

### DIFF
--- a/FactCheckerApp/FactCheckerAppTests/ExportWorkflowTests.swift
+++ b/FactCheckerApp/FactCheckerAppTests/ExportWorkflowTests.swift
@@ -1,0 +1,40 @@
+import XCTest
+import AVFoundation
+@testable import FactCheckerApp
+
+class ExportWorkflowTests: XCTestCase {
+    func testExportRecordingCompletes() async throws {
+        guard let format = AVAudioFormat(standardFormatWithSampleRate: 44100, channels: 1),
+              let buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: 4410) else {
+            XCTFail("Failed to create buffer")
+            return
+        }
+        buffer.frameLength = 4410
+
+        let recordingURL = try await AudioFileManager.shared.saveAudioFile(buffer, filename: "ExportWorkflowTest")
+        defer { try? AudioFileManager.shared.deleteAudioFile(at: recordingURL) }
+
+        let info = AudioFileInfo(
+            url: recordingURL,
+            name: "ExportWorkflowTest",
+            size: Int(buffer.frameLength),
+            creationDate: Date(),
+            modificationDate: Date(),
+            format: .m4a
+        )
+
+        let expectation = XCTestExpectation(description: "Export finished")
+        ExportManager.shared.exportRecording(info, format: .m4a, quality: .low) { result in
+            switch result {
+            case .success(let outputURL):
+                XCTAssertTrue(FileManager.default.fileExists(atPath: outputURL.path))
+                try? FileManager.default.removeItem(at: outputURL)
+            case .failure(let error):
+                XCTFail("Export failed: \(error)")
+            }
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: 10.0)
+    }
+}

--- a/FactCheckerApp/FactCheckerAppTests/RecordingWorkflowTests.swift
+++ b/FactCheckerApp/FactCheckerAppTests/RecordingWorkflowTests.swift
@@ -1,0 +1,20 @@
+import XCTest
+import AVFoundation
+@testable import FactCheckerApp
+
+class RecordingWorkflowTests: XCTestCase {
+    func testSavingRecordingCreatesFile() async throws {
+        guard let format = AVAudioFormat(standardFormatWithSampleRate: 44100, channels: 1),
+              let buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: 4410) else {
+            XCTFail("Failed to create buffer")
+            return
+        }
+        buffer.frameLength = 4410
+
+        let url = try await AudioFileManager.shared.saveAudioFile(buffer, filename: "TestRecording")
+        defer { try? AudioFileManager.shared.deleteAudioFile(at: url) }
+
+        let files = AudioFileManager.shared.getAllAudioFiles()
+        XCTAssertTrue(files.contains(where: { $0.url == url }))
+    }
+}

--- a/FactCheckerApp/FactCheckerAppTests/SyncWorkflowTests.swift
+++ b/FactCheckerApp/FactCheckerAppTests/SyncWorkflowTests.swift
@@ -1,0 +1,11 @@
+import XCTest
+@testable import FactCheckerApp
+
+class SyncWorkflowTests: XCTestCase {
+    func testSyncRecordingsUpdatesState() async {
+        let manager = CloudSyncManager.shared
+        await manager.syncRecordings()
+        XCTAssertFalse(manager.isSyncing)
+        XCTAssertNotNil(manager.lastSyncDate)
+    }
+}


### PR DESCRIPTION
## Summary
- add `RecordingWorkflowTests` for saving a recording
- add `ExportWorkflowTests` covering export logic
- add `SyncWorkflowTests` to check syncing state changes

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68859609674c8323988ef4d2d43f426a